### PR TITLE
YT-PYCC-8: Add the with_strict_types parameter

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - '*'
+    paths:
+      - src/
+      - test/
 
 jobs:
   check_format:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - '*'
+    paths:
+      - src/
+      - test/
 
 jobs:
   run_tests:

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo Cleaning the build files...
+
+find . -type d -name "__pycache__" -exec rm -r {} +
+rm -r .pytest_cache/ .tox/ .coverage coverage.* src/pyconstclasses.egg-info/

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,15 +3,15 @@
 #!/bin/bash
 
 if [ -z "$1" ]; then
-  echo "Usage: $0 <path>"
-  exit 1
+    echo "Usage: $0 <path>"
+    exit 1
 fi
 
 TARGET_PATH=$1
 black $TARGET_PATH && isort $TARGET_PATH
 
 if [ $? -eq 0 ]; then
-  echo "Successfully formatted and sorted imports for $TARGET_PATH"
+    echo "Successfully formatted and sorted imports for $TARGET_PATH"
 else
-  echo "There was an error formatting or sorting imports for $TARGET_PATH"
+    echo "There was an error formatting or sorting imports for $TARGET_PATH"
 fi

--- a/src/constclasses/const_class.py
+++ b/src/constclasses/const_class.py
@@ -1,10 +1,13 @@
 from .ccerror import ConstError, InitializationError
+from .const_class_base import ConstClassBase
 
 
-def _const_class_impl(cls):
+def const_class_impl(cls, with_strict_types: bool):
     class ConstClass(cls):
         def __init__(self, *args, **kwargs):
             super(ConstClass, self).__init__()
+
+            self.__dict__["_cc_base"] = ConstClassBase(with_strict_types=with_strict_types)
 
             if len(args) != len(cls.__annotations__):
                 raise InitializationError.invalid_number_of_arguments(
@@ -12,7 +15,7 @@ def _const_class_impl(cls):
                 )
 
             for i, (attr_name, attr_type) in enumerate(cls.__annotations__.items()):
-                self.__dict__[attr_name] = attr_type(args[i])
+                self.__dict__[attr_name] = self._cc_base.process_attribute_type(attr_name, attr_type, args[i])
 
         def __setattr__(self, attr_name: str, _) -> None:
             raise ConstError(cls.__name__, attr_name)
@@ -23,8 +26,8 @@ def _const_class_impl(cls):
     return ConstClass
 
 
-def const_class(cls=None):
+def const_class(cls=None, /, *, with_strict_types: bool = False):
     def _wrap(cls):
-        return _const_class_impl(cls)
+        return const_class_impl(cls, with_strict_types)
 
     return _wrap if cls is None else _wrap(cls)

--- a/src/constclasses/const_class.py
+++ b/src/constclasses/const_class.py
@@ -7,7 +7,9 @@ def const_class_impl(cls, with_strict_types: bool):
         def __init__(self, *args, **kwargs):
             super(ConstClass, self).__init__()
 
-            self.__dict__["_cc_base"] = ConstClassBase(with_strict_types=with_strict_types)
+            self.__dict__["_cc_base"] = ConstClassBase(
+                with_strict_types=with_strict_types
+            )
 
             if len(args) != len(cls.__annotations__):
                 raise InitializationError.invalid_number_of_arguments(
@@ -15,7 +17,9 @@ def const_class_impl(cls, with_strict_types: bool):
                 )
 
             for i, (attr_name, attr_type) in enumerate(cls.__annotations__.items()):
-                self.__dict__[attr_name] = self._cc_base.process_attribute_type(attr_name, attr_type, args[i])
+                self.__dict__[attr_name] = self._cc_base.process_attribute_type(
+                    attr_name, attr_type, args[i]
+                )
 
         def __setattr__(self, attr_name: str, _) -> None:
             raise ConstError(cls.__name__, attr_name)

--- a/src/constclasses/const_class_base.py
+++ b/src/constclasses/const_class_base.py
@@ -1,0 +1,15 @@
+class ConstClassBase:
+    def __init__(self, /, *, with_strict_types: bool = False):
+        self._with_strict_types = with_strict_types
+
+    def process_attribute_type(self, attr_name, attr_type, attr_value):
+        if self._with_strict_types:
+            if not isinstance(attr_value, attr_type):
+                raise TypeError(
+                    f"Attribute value does not match the declared type:\n"
+                    f"\tattribute: {attr_name}, declared type: {attr_type}, actual type: {type(attr_value)}"
+                )
+
+            return attr_value
+
+        return attr_type(attr_value)

--- a/src/constclasses/static_const_class.py
+++ b/src/constclasses/static_const_class.py
@@ -4,11 +4,11 @@ from .ccerror import ConstError
 def static_const_class(cls):
     class StaticConstClass(cls):
         def __init__(self, *args, **kwargs):
-            self.__dict__["_initialized"] = False
+            self.__dict__["_cc_initialized"] = False
             super(StaticConstClass, self).__init__(*args, **kwargs)
 
         def __setattr__(self, attr_name: str, value) -> None:
-            if self._initialized:
+            if self._cc_initialized:
                 raise ConstError(cls.__name__, attr_name)
             self.__dict__[attr_name] = value
 
@@ -20,7 +20,7 @@ def static_const_class(cls):
     instance = StaticConstClass()
     for attr_name, attr_type in StaticConstClass.__annotations__.items():
         setattr(instance, attr_name, attr_type(cls_vars[attr_name]))
-    instance._initialized = True
+    instance._cc_initialized = True
 
     return instance
 

--- a/src/constclasses/static_const_class.py
+++ b/src/constclasses/static_const_class.py
@@ -1,11 +1,13 @@
 from .ccerror import ConstError
+from .const_class_base import ConstClassBase
 
 
-def static_const_class(cls):
+def static_const_class(cls, /, *, with_strict_types: bool = False):
     class StaticConstClass(cls):
         def __init__(self, *args, **kwargs):
-            self.__dict__["_cc_initialized"] = False
             super(StaticConstClass, self).__init__(*args, **kwargs)
+            self.__dict__["_cc_initialized"] = False
+            self.__dict__["_cc_base"] = ConstClassBase(with_strict_types=with_strict_types)
 
         def __setattr__(self, attr_name: str, value) -> None:
             if self._cc_initialized:
@@ -19,7 +21,7 @@ def static_const_class(cls):
     cls_vars = vars(cls)
     instance = StaticConstClass()
     for attr_name, attr_type in StaticConstClass.__annotations__.items():
-        setattr(instance, attr_name, attr_type(cls_vars[attr_name]))
+        setattr(instance, attr_name, instance._cc_base.process_attribute_type(attr_name, attr_type, cls_vars[attr_name]))
     instance._cc_initialized = True
 
     return instance

--- a/src/constclasses/static_const_class.py
+++ b/src/constclasses/static_const_class.py
@@ -7,7 +7,9 @@ def static_const_class(cls, /, *, with_strict_types: bool = False):
         def __init__(self, *args, **kwargs):
             super(StaticConstClass, self).__init__(*args, **kwargs)
             self.__dict__["_cc_initialized"] = False
-            self.__dict__["_cc_base"] = ConstClassBase(with_strict_types=with_strict_types)
+            self.__dict__["_cc_base"] = ConstClassBase(
+                with_strict_types=with_strict_types
+            )
 
         def __setattr__(self, attr_name: str, value) -> None:
             if self._cc_initialized:
@@ -21,7 +23,13 @@ def static_const_class(cls, /, *, with_strict_types: bool = False):
     cls_vars = vars(cls)
     instance = StaticConstClass()
     for attr_name, attr_type in StaticConstClass.__annotations__.items():
-        setattr(instance, attr_name, instance._cc_base.process_attribute_type(attr_name, attr_type, cls_vars[attr_name]))
+        setattr(
+            instance,
+            attr_name,
+            instance._cc_base.process_attribute_type(
+                attr_name, attr_type, cls_vars[attr_name]
+            ),
+        )
     instance._cc_initialized = True
 
     return instance

--- a/test/common.py
+++ b/test/common.py
@@ -1,0 +1,17 @@
+from constclasses.const_class import const_class
+from constclasses.static_const_class import static_const_class
+
+X1, S1 = 1, "str1"
+X2, S2 = 2, "str2"
+
+
+@const_class
+class ConstClass:
+    x: int
+    s: str
+
+
+@static_const_class
+class StaticConstClass:
+    x: int = X1
+    s: str = S1

--- a/test/test_const_class.py
+++ b/test/test_const_class.py
@@ -1,12 +1,7 @@
 import pytest
 from constclasses.ccerror import ConstError, InitializationError
-from constclasses.const_class import const_class
 
-
-@const_class
-class ConstClass:
-    x: int
-    s: str
+from .common import S1, S2, X1, X2, ConstClass
 
 
 @pytest.mark.parametrize(
@@ -22,23 +17,20 @@ def test_const_class_initialization_with_invalid_number_of_arguments(init_args: 
 
 
 def test_const_class_member_modification():
-    x1, s1 = 1, "str1"
-    x2, s2 = 2, "str2"
-
-    const_instance = ConstClass(x1, s1)
-
-    with pytest.raises(ConstError) as err:
-        const_instance.x = x2
-
     build_err_msg = (
         lambda member: f"Cannot modify const attribute `{member}` of class `{ConstClass.__name__}`"
     )
+
+    const_instance = ConstClass(X1, S1)
+
+    with pytest.raises(ConstError) as err:
+        const_instance.x = X2
 
     err_msg = str(err.value)
     assert err_msg == build_err_msg("x")
 
     with pytest.raises(ConstError) as err:
-        const_instance.s = s2
+        const_instance.s = S2
 
     err_msg = str(err.value)
     assert err_msg == build_err_msg("s")

--- a/test/test_const_class_base.py
+++ b/test/test_const_class_base.py
@@ -1,0 +1,54 @@
+import pytest
+from constclasses.const_class_base import ConstClassBase
+from .utility import assert_does_not_throw
+
+
+def test_process_attribute_type_without_strict_types():
+    """
+    The process_attribute_type function should return a valid value
+    for an attribute if the given values can be converted to the
+    declared types.
+    """
+
+    sut = ConstClassBase(with_strict_types=False)
+
+    attr_name = "x"
+    attr_type = int
+    attr_value_exact_type = 3
+    attr_value_convertible_type = 3.14
+
+    assert (
+        sut.process_attribute_type(attr_name, attr_type, attr_value_exact_type)
+        == attr_value_exact_type
+    )
+    assert sut.process_attribute_type(
+        attr_name, attr_type, attr_value_convertible_type
+    ) == attr_type(attr_value_convertible_type)
+
+
+def test_process_attribute_type_with_strict_types():
+    """
+    The process_attribute_type functionshould return a valid value
+    for an attribute only when the given value is an instance of
+    the declared type. Otherwise it should throw an error.
+    """
+
+    sut = ConstClassBase(with_strict_types=True)
+
+    class BaseClass:
+        pass
+
+    class DerivedClass(BaseClass):
+        pass
+
+    class NotDerivedClass:
+        pass
+
+    attr_name = "x"
+    attr_type = BaseClass
+
+    assert_does_not_throw(lambda: sut.process_attribute_type(attr_name, attr_type, BaseClass()))
+    assert_does_not_throw(lambda: sut.process_attribute_type(attr_name, attr_type, DerivedClass()))
+
+    with pytest.raises(TypeError):
+        sut.process_attribute_type(attr_name, attr_type, NotDerivedClass())

--- a/test/test_const_class_base.py
+++ b/test/test_const_class_base.py
@@ -1,5 +1,6 @@
 import pytest
 from constclasses.const_class_base import ConstClassBase
+
 from .utility import assert_does_not_throw
 
 
@@ -47,8 +48,12 @@ def test_process_attribute_type_with_strict_types():
     attr_name = "x"
     attr_type = BaseClass
 
-    assert_does_not_throw(lambda: sut.process_attribute_type(attr_name, attr_type, BaseClass()))
-    assert_does_not_throw(lambda: sut.process_attribute_type(attr_name, attr_type, DerivedClass()))
+    assert_does_not_throw(
+        lambda: sut.process_attribute_type(attr_name, attr_type, BaseClass())
+    )
+    assert_does_not_throw(
+        lambda: sut.process_attribute_type(attr_name, attr_type, DerivedClass())
+    )
 
     with pytest.raises(TypeError):
         sut.process_attribute_type(attr_name, attr_type, NotDerivedClass())

--- a/test/test_static_const_class.py
+++ b/test/test_static_const_class.py
@@ -1,45 +1,38 @@
 import pytest
 from constclasses.ccerror import ConstError, InitializationError
-from constclasses.static_const_class import mutable_instance, static_const_class
+from constclasses.static_const_class import mutable_instance
 
-X1, S1 = 1, "str1"
-X2, S2 = 2, "str2"
-
-
-@static_const_class
-class StaticConstResource:
-    x: int = X1
-    s: str = S1
+from .common import S1, S2, X1, X2, StaticConstClass
 
 
 def test_static_const_class_initialization_error():
     with pytest.raises(TypeError) as err:
-        _ = StaticConstResource(X2, S2)
+        _ = StaticConstClass(X2, S2)
 
     err_msg = str(err.value)
-    assert err_msg == "'StaticConstResource' object is not callable"
+    assert err_msg == "'StaticConstClass' object is not callable"
 
 
 def test_static_const_class_member_modification():
-    with pytest.raises(ConstError) as err:
-        StaticConstResource.x = X2
-
     build_err_msg = (
-        lambda member: f"Cannot modify const attribute `{member}` of class `StaticConstResource`"
+        lambda member: f"Cannot modify const attribute `{member}` of class `StaticConstClass`"
     )
+
+    with pytest.raises(ConstError) as err:
+        StaticConstClass.x = X2
 
     err_msg = str(err.value)
     assert err_msg == build_err_msg("x")
 
     with pytest.raises(ConstError) as err:
-        StaticConstResource.s = S2
+        StaticConstClass.s = S2
 
     err_msg = str(err.value)
     assert err_msg == build_err_msg("s")
 
 
 def test_mutable_instance_of_static_const_class():
-    mut_instance = mutable_instance(StaticConstResource)
+    mut_instance = mutable_instance(StaticConstClass)
 
     assert mut_instance.x == X1
     assert mut_instance.s == S1
@@ -49,7 +42,3 @@ def test_mutable_instance_of_static_const_class():
 
     mut_instance.s = S2
     assert mut_instance.s == S2
-
-
-if __name__ == "__main__":
-    mut_instance = mutable_instance(StaticConstResource)

--- a/test/utility.py
+++ b/test/utility.py
@@ -5,4 +5,4 @@ def assert_does_not_throw(func):
     try:
         func()
     except Exception as err:
-        pytest.fail(f"Unexpected exception {type(err)}\n\twhat: {err}")
+        pytest.fail(f"Unexpected exception {type(err)}\nWhat:\n{err}")

--- a/test/utility.py
+++ b/test/utility.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+def assert_does_not_throw(func):
+    try:
+        func()
+    except Exception as err:
+        pytest.fail(f"Unexpected exception {type(err)}\n\twhat: {err}")


### PR DESCRIPTION
Added the `with_strict_types : bool` parameter to the const class decorators.
Depending on this parameter the class returned from the decorator initializes the member values of a class instance or a static class by:
  * Converting the value to a desired type: e.g. `self.__dict__[attr_name] = attr_type(args[i])`
  * Throwing an error if a value is not an instance of the desired type: e.g.
     ```python
     if not isinstance(args[i], attr_type):
         raise InvalidTypeError(msg)
     self.__dict__[attr_name] = args[i]
     ```