### PR TITLE
YT-PYCC-6: Add the with_kwargs parameter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure bash scripts have unix style new line encoding
+*.sh text eol=lf

--- a/src/constclasses/const_class.py
+++ b/src/constclasses/const_class.py
@@ -14,7 +14,7 @@ def const_class_impl(
             )
 
             if with_kwargs:
-                for i, (attr_name, attr_type) in enumerate(cls.__annotations__.items()):
+                for attr_name, attr_type in cls.__annotations__.items():
                     self.__dict__[attr_name] = self._cc_base.process_attribute_type(
                         attr_name, attr_type, kwargs.get(attr_name)
                     )

--- a/src/constclasses/const_class.py
+++ b/src/constclasses/const_class.py
@@ -2,7 +2,7 @@ from .ccerror import ConstError, InitializationError
 from .const_class_base import CC_BASE_ATTR_NAME, ConstClassBase
 
 
-def const_class_impl(cls, with_strict_types: bool, include: set[str], exclude: set[str]):
+def const_class_impl(cls, with_kwargs: bool, with_strict_types: bool, include: set[str], exclude: set[str]):
     class ConstClass(cls):
         def __init__(self, *args, **kwargs):
             super(ConstClass, self).__init__()
@@ -11,15 +11,21 @@ def const_class_impl(cls, with_strict_types: bool, include: set[str], exclude: s
                 with_strict_types=with_strict_types, include=include, exclude=exclude
             )
 
-            if len(args) != len(cls.__annotations__):
-                raise InitializationError.invalid_number_of_arguments(
-                    len(cls.__annotations__), len(args)
-                )
+            if with_kwargs:
+                for i, (attr_name, attr_type) in enumerate(cls.__annotations__.items()):
+                    self.__dict__[attr_name] = self._cc_base.process_attribute_type(
+                        attr_name, attr_type, kwargs.get(attr_name)
+                    )
+            else:
+                if len(args) != len(cls.__annotations__):
+                    raise InitializationError.invalid_number_of_arguments(
+                        len(cls.__annotations__), len(args)
+                    )
 
-            for i, (attr_name, attr_type) in enumerate(cls.__annotations__.items()):
-                self.__dict__[attr_name] = self._cc_base.process_attribute_type(
-                    attr_name, attr_type, args[i]
-                )
+                for i, (attr_name, attr_type) in enumerate(cls.__annotations__.items()):
+                    self.__dict__[attr_name] = self._cc_base.process_attribute_type(
+                        attr_name, attr_type, args[i]
+                    )
 
         def __setattr__(self, attr_name: str, attr_value) -> None:
             if self._cc_base.is_const_attribute(attr_name):
@@ -38,11 +44,12 @@ def const_class(
     cls=None,
     /,
     *,
+    with_kwargs: bool = False,
     with_strict_types: bool = False,
     include: set[str] = None,
     exclude: set[str] = None,
 ):
     def _wrap(cls):
-        return const_class_impl(cls, with_strict_types, include, exclude)
+        return const_class_impl(cls, with_kwargs, with_strict_types, include, exclude)
 
     return _wrap if cls is None else _wrap(cls)

--- a/src/constclasses/const_class.py
+++ b/src/constclasses/const_class.py
@@ -2,7 +2,9 @@ from .ccerror import ConstError, InitializationError
 from .const_class_base import CC_BASE_ATTR_NAME, ConstClassBase
 
 
-def const_class_impl(cls, with_kwargs: bool, with_strict_types: bool, include: set[str], exclude: set[str]):
+def const_class_impl(
+    cls, with_kwargs: bool, with_strict_types: bool, include: set[str], exclude: set[str]
+):
     class ConstClass(cls):
         def __init__(self, *args, **kwargs):
             super(ConstClass, self).__init__()

--- a/test/test_const_class.py
+++ b/test/test_const_class.py
@@ -30,6 +30,44 @@ def test_initialization_with_invalid_number_of_arguments(init_args: list):
     assert util.msg(err).startswith("Invalid number of arguments")
 
 
+def test_initialization_with_args():
+    @const_class(with_kwargs=False)
+    class ConstClassArgs:
+        x: int
+        s: str
+
+    with pytest.raises(InitializationError):
+        _ = ConstClassArgs()
+
+    const_instance = None
+    def _test_args():
+        nonlocal const_instance
+        const_instance = ConstClassArgs(*(ATTR_VALS_1.values()))
+
+    util.assert_does_not_throw(_test_args)
+    for attr_name, attr_value in ATTR_VALS_1.items():
+        assert getattr(const_instance, attr_name) == attr_value
+
+
+def test_initialization_with_kwargs():
+    @const_class(with_kwargs=True)
+    class ConstClassKwargs:
+        x: int
+        s: str
+
+    with pytest.raises(TypeError):
+        _ = ConstClassKwargs(*(ATTR_VALS_1.values()))
+
+    const_instance = None
+    def _test_kwargs():
+        nonlocal const_instance
+        const_instance = ConstClassKwargs(**ATTR_VALS_1)
+
+    util.assert_does_not_throw(_test_kwargs)
+    for attr_name, attr_value in ATTR_VALS_1.items():
+        assert getattr(const_instance, attr_name) == attr_value
+
+
 def test_member_modification():
     const_instance = ConstClass(*(ATTR_VALS_1.values()))
 

--- a/test/test_const_class.py
+++ b/test/test_const_class.py
@@ -40,6 +40,7 @@ def test_initialization_with_args():
         _ = ConstClassArgs()
 
     const_instance = None
+
     def _test_args():
         nonlocal const_instance
         const_instance = ConstClassArgs(*(ATTR_VALS_1.values()))
@@ -59,6 +60,7 @@ def test_initialization_with_kwargs():
         _ = ConstClassKwargs(*(ATTR_VALS_1.values()))
 
     const_instance = None
+
     def _test_kwargs():
         nonlocal const_instance
         const_instance = ConstClassKwargs(**ATTR_VALS_1)


### PR DESCRIPTION
Added:
- the with_kwargs parameter to the const_class decorator.
- unit tests for the added functionality
- .gitattributes file with .sh file new line encodings set to lf 