### PR TITLE
YT-PYCC-9: Add the inherit_constructor parameter

### DIFF
--- a/src/constclasses/const_class.py
+++ b/src/constclasses/const_class.py
@@ -1,5 +1,9 @@
 from .ccerror import ConstError, InitializationError
-from .const_class_base import CC_BASE_ATTR_NAME, CC_INITIALIZED_ATTR_NAME, ConstClassBase
+from .const_class_base import (
+    CC_BASE_ATTR_NAME,
+    CC_INITIALIZED_ATTR_NAME,
+    ConstClassBase,
+)
 
 
 def const_class_impl(

--- a/src/constclasses/const_class.py
+++ b/src/constclasses/const_class.py
@@ -1,17 +1,29 @@
-from .ccerror import ConstError, InitializationError
-from .const_class_base import CC_BASE_ATTR_NAME, ConstClassBase
+from .ccerror import ConfigurationError, ConstError, InitializationError
+from .const_class_base import CC_BASE_ATTR_NAME, MANDATORY_CONST_ATTRS, ConstClassBase
 
 
 def const_class_impl(
-    cls, with_kwargs: bool, with_strict_types: bool, include: set[str], exclude: set[str]
+    cls,
+    with_kwargs: bool,
+    with_strict_types: bool,
+    include: set[str],
+    exclude: set[str],
+    inherit_constructor: bool,
 ):
     class ConstClass(cls):
         def __init__(self, *args, **kwargs):
-            super(ConstClass, self).__init__()
-
             self.__dict__[CC_BASE_ATTR_NAME] = ConstClassBase(
                 with_strict_types=with_strict_types, include=include, exclude=exclude
             )
+
+            if inherit_constructor:
+                super(ConstClass, self).__init__(*args, **kwargs)
+                return
+            else:
+                super(ConstClass, self).__init__()
+
+            if inherit_constructor:
+                return
 
             if with_kwargs:
                 for attr_name, attr_type in cls.__annotations__.items():
@@ -50,8 +62,11 @@ def const_class(
     with_strict_types: bool = False,
     include: set[str] = None,
     exclude: set[str] = None,
+    inherit_constructor=False,
 ):
     def _wrap(cls):
-        return const_class_impl(cls, with_kwargs, with_strict_types, include, exclude)
+        return const_class_impl(
+            cls, with_kwargs, with_strict_types, include, exclude, inherit_constructor
+        )
 
     return _wrap if cls is None else _wrap(cls)

--- a/src/constclasses/const_class.py
+++ b/src/constclasses/const_class.py
@@ -1,5 +1,5 @@
-from .ccerror import ConfigurationError, ConstError, InitializationError
-from .const_class_base import CC_BASE_ATTR_NAME, MANDATORY_CONST_ATTRS, ConstClassBase
+from .ccerror import ConstError, InitializationError
+from .const_class_base import CC_BASE_ATTR_NAME, CC_INITIALIZED_ATTR_NAME, ConstClassBase
 
 
 def const_class_impl(
@@ -15,15 +15,14 @@ def const_class_impl(
             self.__dict__[CC_BASE_ATTR_NAME] = ConstClassBase(
                 with_strict_types=with_strict_types, include=include, exclude=exclude
             )
+            self.__dict__[CC_INITIALIZED_ATTR_NAME] = False
 
             if inherit_constructor:
                 super(ConstClass, self).__init__(*args, **kwargs)
+                self._cc_initialized = True
                 return
             else:
                 super(ConstClass, self).__init__()
-
-            if inherit_constructor:
-                return
 
             if with_kwargs:
                 for attr_name, attr_type in cls.__annotations__.items():
@@ -41,8 +40,10 @@ def const_class_impl(
                         attr_name, attr_type, args[i]
                     )
 
+            self._cc_initialized = True
+
         def __setattr__(self, attr_name: str, attr_value) -> None:
-            if self._cc_base.is_const_attribute(attr_name):
+            if self._cc_initialized and self._cc_base.is_const_attribute(attr_name):
                 raise ConstError(cls.__name__, attr_name)
             self.__dict__[attr_name] = self._cc_base.process_attribute_type(
                 attr_name, cls.__annotations__.get(attr_name), attr_value

--- a/src/constclasses/const_class_base.py
+++ b/src/constclasses/const_class_base.py
@@ -9,11 +9,18 @@ class ConstClassBase:
     def __init__(
         self,
         /,
+        cls_attrs: set[str] = set(),
         *,
         include: set[str] = None,
         exclude: set[str] = None,
         with_strict_types: bool = False,
     ):
+        intersection = cls_attrs & MANDATORY_CONST_ATTRS
+        if intersection:
+            raise ConfigurationError(
+                f"Const class cannot have members: [{', '.join(intersection)}]"
+            )
+
         if include is not None and exclude is not None:
             raise ConfigurationError(
                 "`include` and `exclude` parameters cannot be used simultaneously"

--- a/src/constclasses/static_const_class.py
+++ b/src/constclasses/static_const_class.py
@@ -12,10 +12,10 @@ def static_const_class_impl(
 ):
     class StaticConstClass(cls):
         def __init__(self, *args, **kwargs):
-            super(StaticConstClass, self).__init__(*args, **kwargs)
             self.__dict__[CC_BASE_ATTR_NAME] = ConstClassBase(
                 with_strict_types=with_strict_types, include=include, exclude=exclude
             )
+            super(StaticConstClass, self).__init__()
             self.__dict__[CC_INITIALIZED_ATTR_NAME] = False
 
         def __setattr__(self, attr_name: str, attr_value) -> None:

--- a/src/constclasses/static_const_class.py
+++ b/src/constclasses/static_const_class.py
@@ -15,8 +15,8 @@ def static_const_class_impl(
             self.__dict__[CC_BASE_ATTR_NAME] = ConstClassBase(
                 with_strict_types=with_strict_types, include=include, exclude=exclude
             )
-            super(StaticConstClass, self).__init__()
             self.__dict__[CC_INITIALIZED_ATTR_NAME] = False
+            super(StaticConstClass, self).__init__()
 
         def __setattr__(self, attr_name: str, attr_value) -> None:
             if self._cc_initialized and self._cc_base.is_const_attribute(attr_name):

--- a/test/common/utility.py
+++ b/test/common/utility.py
@@ -5,6 +5,10 @@ def msg(err: Exception) -> str:
     return str(err.value)
 
 
+def config_not_empty_cls_attrs_intersection_msg_prefix() -> str:
+    return "Const class cannot have members"
+
+
 def config_include_and_exclude_used_error_msg_postfix() -> str:
     return "`include` and `exclude` parameters cannot be used simultaneously"
 

--- a/test/test_const_class.py
+++ b/test/test_const_class.py
@@ -5,6 +5,7 @@ from constclasses.ccerror import ConstError, InitializationError
 from constclasses.const_class import const_class
 from constclasses.const_class_base import MANDATORY_CONST_ATTRS
 
+
 X_ATTR_NAME = "x"
 S_ATTR_NAME = "s"
 ATTR_NAMES = {X_ATTR_NAME, S_ATTR_NAME}
@@ -176,3 +177,24 @@ def test_member_modification_with_strict_types():
         with pytest.raises(TypeError) as err:
             setattr(const_instance, attr_name, DUMMY_VALUE)
         assert util.msg(err).startswith(util.invalid_type_error_msg_prefix())
+
+
+def test_initialization_with_inherited_constructor():
+    @const_class(inherit_constructor=True)
+    class ConstClassWithConstructor:
+        x: int
+        s: str
+
+        def __init__(self, x: int):
+            self.x = x
+            self.s = str(x)
+
+    x_value = ATTR_VALS_1[X_ATTR_NAME]
+    const_instance = None
+    def _initialize():
+        nonlocal const_instance
+        const_instance = ConstClassWithConstructor(x_value)
+
+    util.assert_does_not_throw(_initialize)
+    assert const_instance.x == x_value
+    assert const_instance.s == str(x_value)

--- a/test/test_const_class.py
+++ b/test/test_const_class.py
@@ -5,7 +5,6 @@ from constclasses.ccerror import ConstError, InitializationError
 from constclasses.const_class import const_class
 from constclasses.const_class_base import MANDATORY_CONST_ATTRS
 
-
 X_ATTR_NAME = "x"
 S_ATTR_NAME = "s"
 ATTR_NAMES = {X_ATTR_NAME, S_ATTR_NAME}
@@ -191,6 +190,7 @@ def test_initialization_with_inherited_constructor():
 
     x_value = ATTR_VALS_1[X_ATTR_NAME]
     const_instance = None
+
     def _initialize():
         nonlocal const_instance
         const_instance = ConstClassWithConstructor(x_value)

--- a/test/test_const_class_base.py
+++ b/test/test_const_class_base.py
@@ -4,10 +4,8 @@ import pytest
 from constclasses.ccerror import ConfigurationError
 from constclasses.const_class_base import MANDATORY_CONST_ATTRS, ConstClassBase
 
-# TODO: add test cases for valid configuration
 
-
-def test_setup_for_class_attrs_intersecting_with_mandatory_const_attrs():
+def test_init_for_class_attrs_intersecting_with_mandatory_const_attrs():
     for attr_name in MANDATORY_CONST_ATTRS:
         with pytest.raises(ConfigurationError) as err:
             _ = ConstClassBase(cls_attrs={attr_name})
@@ -18,7 +16,7 @@ def test_setup_for_class_attrs_intersecting_with_mandatory_const_attrs():
     assert util.config_not_empty_cls_attrs_intersection_msg_prefix() in util.msg(err)
 
 
-def test_setup_for_not_none_include_and_exclude_parameters():
+def test_init_for_not_none_include_and_exclude_parameters():
     with pytest.raises(ConfigurationError) as err:
         _ = ConstClassBase(include={}, exclude={})
 
@@ -27,7 +25,7 @@ def test_setup_for_not_none_include_and_exclude_parameters():
     )
 
 
-def test_setup_for_exclude_intersecting_with_mandatory_const_fields():
+def test_init_for_exclude_intersecting_with_mandatory_const_fields():
     for mandatory_const_attr in MANDATORY_CONST_ATTRS:
         with pytest.raises(ConfigurationError) as err:
             _ = ConstClassBase(exclude={mandatory_const_attr})
@@ -42,6 +40,11 @@ def test_setup_for_exclude_intersecting_with_mandatory_const_fields():
 
     err_msg = str(err.value)
     assert err_msg.endswith(util.config_invalid_exclude_error_msg(MANDATORY_CONST_ATTRS))
+
+def test_init_with_valid_parameter_configuration():
+    def _test():
+        _ = ConstClassBase()
+    util.assert_does_not_throw(_test)
 
 
 @pytest.fixture

--- a/test/test_const_class_base.py
+++ b/test/test_const_class_base.py
@@ -41,9 +41,11 @@ def test_init_for_exclude_intersecting_with_mandatory_const_fields():
     err_msg = str(err.value)
     assert err_msg.endswith(util.config_invalid_exclude_error_msg(MANDATORY_CONST_ATTRS))
 
+
 def test_init_with_valid_parameter_configuration():
     def _test():
         _ = ConstClassBase()
+
     util.assert_does_not_throw(_test)
 
 

--- a/test/test_const_class_base.py
+++ b/test/test_const_class_base.py
@@ -4,8 +4,21 @@ import pytest
 from constclasses.ccerror import ConfigurationError
 from constclasses.const_class_base import MANDATORY_CONST_ATTRS, ConstClassBase
 
+# TODO: add test cases for valid configuration
 
-def test_const_class_base_setup_for_not_none_include_and_exclude_parameters():
+
+def test_setup_for_class_attrs_intersecting_with_mandatory_const_attrs():
+    for attr_name in MANDATORY_CONST_ATTRS:
+        with pytest.raises(ConfigurationError) as err:
+            _ = ConstClassBase(cls_attrs={attr_name})
+        assert util.config_not_empty_cls_attrs_intersection_msg_prefix() in util.msg(err)
+
+    with pytest.raises(ConfigurationError) as err:
+        _ = ConstClassBase(cls_attrs=MANDATORY_CONST_ATTRS)
+    assert util.config_not_empty_cls_attrs_intersection_msg_prefix() in util.msg(err)
+
+
+def test_setup_for_not_none_include_and_exclude_parameters():
     with pytest.raises(ConfigurationError) as err:
         _ = ConstClassBase(include={}, exclude={})
 
@@ -14,7 +27,7 @@ def test_const_class_base_setup_for_not_none_include_and_exclude_parameters():
     )
 
 
-def test_const_class_base_setup_for_exclude_intersecting_with_mandatory_const_fields():
+def test_setup_for_exclude_intersecting_with_mandatory_const_fields():
     for mandatory_const_attr in MANDATORY_CONST_ATTRS:
         with pytest.raises(ConfigurationError) as err:
             _ = ConstClassBase(exclude={mandatory_const_attr})


### PR DESCRIPTION
Added the `inherit_constructor` parameter to the `const_class` decorator and unit tests covering the added functionality.