### PR TITLE
Separate tests and coverage workflows

### DIFF
--- a/.github/workflows/covbadge.yaml
+++ b/.github/workflows/covbadge.yaml
@@ -1,0 +1,53 @@
+name: covbadge
+on:
+  push:
+    branches:
+      - '*'
+    paths:
+      - .github/workflows/coverage.yaml
+      - src/**
+      - test/**
+      - tox.ini
+
+jobs:
+  coverage:
+    name: Generate coverage status badge
+    needs: run_tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: |
+          python -m pip install tox tox-gh-actions
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v4
+        with:
+          pattern: covdata-*
+          merge-multiple: true
+
+      - name: Combine coverage data
+        run: |
+          python -m tox -e coverage
+          export TOTAL_COV=$(python -c "import json; print(json.load(open('coverage.json'))['totals']['percent_covered_display'])")
+          echo total_cov=$TOTAL_COV >> $GITHUB_ENV
+          echo ### Total coverage: ${TOTAL_COV}% >> $GITHUB_STEP_SUMMARY
+
+      - name: Generate coverage badge
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: f6cec4c4c8e1733cfe45f807918a128a
+          filename: covbadge.json
+          label: coverage
+          message: ${{ env.total_cov }}%
+          minColorRange: 50
+          maxColorRange: 90
+          valColorRange: ${{ env.total_cov }}

--- a/.github/workflows/covbadge.yaml
+++ b/.github/workflows/covbadge.yaml
@@ -10,9 +10,37 @@ on:
       - tox.ini
 
 jobs:
+  run_coverage:
+    name: Run project tests with coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install tox tox-gh-actions
+
+      - name: Run tox for ${{ matrix.python-version }}
+        run: |
+          python -m tox
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: covdata-312
+          path: ./.coverage
+          if-no-files-found: warn
+
   coverage:
     name: Generate coverage status badge
-    needs: run_tests
+    needs: run_coverage
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -30,8 +58,7 @@ jobs:
       - name: Download coverage data
         uses: actions/download-artifact@v4
         with:
-          pattern: covdata-*
-          merge-multiple: true
+          pattern: covdata-312
 
       - name: Combine coverage data
         run: |

--- a/.github/workflows/covbadge.yaml
+++ b/.github/workflows/covbadge.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - '*'
     paths:
-      - .github/workflows/coverage.yaml
+      - .github/workflows/covbadge.yaml
       - src/**
       - test/**
       - tox.ini

--- a/.github/workflows/covbadge.yaml
+++ b/.github/workflows/covbadge.yaml
@@ -35,8 +35,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: covdata-312
-          path: ./.coverage
-          if-no-files-found: warn
+          path: ./.coverage*
+          if-no-files-found: error
 
   coverage:
     name: Generate coverage status badge

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - '*'
     paths:
-      - .github/workflows/examples.yaml
       - src/**
       - examples/**
       - pyproject.toml
@@ -27,13 +26,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: python -m pip install build
+        run: |
+          python -m pip install build
 
       - name: Build the library for ${{ matrix.python-version }}
-        run: python -m build
+        run: |
+          python -m build
 
       - name: Install library
-        run: python -m pip install dist/pyconstclasses-*-py3-none-any.whl --force-reinstall
+        run: |
+          python -m pip install dist/pyconstclasses-*-py3-none-any.whl --force-reinstall
 
       - name: Run the example programs
         run: |

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - '*'
     paths:
+      - .github/workflows/examples.yaml
       - src/**
       - examples/**
       - pyproject.toml

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - '*'
     paths:
-      - .github/workflows/format.yaml
       - src/**
       - test/**
       - examples/**
@@ -25,10 +24,13 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: python -m pip install black isort
+        run: |
+          python -m pip install black isort
 
       - name: Run format check
-        run: python -m black . --check
+        run: |
+          python -m black . --check
 
       - name: Run import check
-        run: python -m isort . --check
+        run: |
+          python -m isort . --check

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - '*'
     paths:
+      - .github/workflows/format.yaml
       - src/**
       - test/**
       - examples/**

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,7 @@ jobs:
           python -m tox
 
       - name: List coverage files
-        run: find . -name .coverage.*
+        run: find . -name .coverage*
 
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
@@ -44,48 +44,3 @@ jobs:
           name: covdata-${{ matrix.python-version }}
           path: ./.coverage
           if-no-files-found: warn
-
-  coverage:
-    name: Generate coverage status badge
-    needs: run_tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-
-      - name: Install dependencies
-        run: |
-          python -m pip install tox tox-gh-actions
-
-      - name: Download coverage data
-        uses: actions/download-artifact@v4
-        with:
-          pattern: covdata-*
-          merge-multiple: true
-
-      - name: List downloaded artifacts
-        run: ls -la
-
-      - name: Combine coverage data
-        run: |
-          python -m tox -e coverage
-          export TOTAL_COV=$(python -c "import json; print(json.load(open('coverage.json'))['totals']['percent_covered_display'])")
-          echo total_cov=$TOTAL_COV >> $GITHUB_ENV
-          echo ### Total coverage: ${TOTAL_COV}% >> $GITHUB_STEP_SUMMARY
-
-      - name: Generate coverage badge
-        uses: schneegans/dynamic-badges-action@v1.7.0
-        with:
-          auth: ${{ secrets.GIST_TOKEN }}
-          gistID: f6cec4c4c8e1733cfe45f807918a128a
-          filename: covbadge.json
-          label: coverage
-          message: ${{ env.total_cov }}%
-          minColorRange: 50
-          maxColorRange: 90
-          valColorRange: ${{ env.total_cov }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,14 +35,14 @@ jobs:
         run: |
           python -m tox
 
-      - name: List files after tests
-        run: ls -la
+      - name: List coverage files
+        run: find . -name .coverage.*
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: covdata-${{ matrix.python-version }}
-          path: .coverage.*
+          path: ".coverage.*"
           if-no-files-found: warn
 
   coverage:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: covdata-${{ matrix.python-version }}
-          path: .coverage.*
+          path: .coverage*
           if-no-files-found: warn
 
   coverage:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install pytest
+          python -m pip install tox
 
       - name: Run tests for ${{ matrix.python-version }}
         run: |
-          python -m pytest -v
+          python -m tox

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - '*'
     paths:
+      - .github/workflows/tests.yaml
       - src/**
       - test/**
       - tox.ini
@@ -34,11 +35,15 @@ jobs:
         run: |
           python -m tox
 
+      - name: List files after tests
+        run: ls -la
+
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
         with:
           name: covdata-${{ matrix.python-version }}
           path: .coverage.*
+          if-no-files-found: warn
 
   coverage:
     name: Generate coverage status badge
@@ -62,6 +67,9 @@ jobs:
         with:
           pattern: covdata-*
           merge-multiple: true
+
+      - name: List downloaded artifacts
+        run: ls -la
 
       - name: Combine coverage data
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - '*'
     paths:
-      - .github/workflows/tests.yaml
       - src/**
       - test/**
       - tox.ini
@@ -28,10 +27,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: python -m pip install tox tox-gh-actions
+        run: |
+          python -m pip install tox tox-gh-actions
 
       - name: Run tox for ${{ matrix.python-version }}
-        run: python -m tox
+        run: |
+          python -m tox
 
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
@@ -53,7 +54,8 @@ jobs:
           python-version: 3.12
 
       - name: Install dependencies
-        run: python -m pip install tox tox-gh-actions
+        run: |
+          python -m pip install tox tox-gh-actions
 
       - name: Download coverage data
         uses: actions/download-artifact@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: covdata-${{ matrix.python-version }}
-          path: "./.coverage.*"
+          path: ./.coverage
           if-no-files-found: warn
 
   coverage:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: covdata-${{ matrix.python-version }}
-          path: ".coverage.*"
+          path: "./.coverage.*"
           if-no-files-found: warn
 
   coverage:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,18 +29,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install tox tox-gh-actions
+          python -m pip install pytest
 
-      - name: Run tox for ${{ matrix.python-version }}
+      - name: Run tests for ${{ matrix.python-version }}
         run: |
-          python -m tox
-
-      - name: List coverage files
-        run: find . -name .coverage*
-
-      - name: Upload coverage data
-        uses: actions/upload-artifact@v4
-        with:
-          name: covdata-${{ matrix.python-version }}
-          path: ./.coverage
-          if-no-files-found: warn
+          python -m pytest -v

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,10 +39,10 @@ jobs:
         run: ls -la
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: covdata-${{ matrix.python-version }}
-          path: .coverage*
+          path: .coverage.*
           if-no-files-found: warn
 
   coverage:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyconstclasses"
-version = "1.0.4"
+version = "1.0"
 description = "Package with const class decoratos and utility"
 authors = [
   {name = "SpectraL519"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyconstclasses"
-version = "1.0"
+version = "1.0.5"
 description = "Package with const class decoratos and utility"
 authors = [
   {name = "SpectraL519"}

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skip_missing_interpreters = True
 deps =
     pytest
     pytest-cov
-    coverage
+    coverage[toml]
 commands =
     python -m coverage run -p -m pytest {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skip_missing_interpreters = True
 deps =
     pytest
     pytest-cov
-    coverage[toml]
+    coverage
 commands =
     python -m coverage run -p -m pytest {posargs}
 


### PR DESCRIPTION
Created separate `tests` and `covbadge` workflows due to an unforeseen `upload-artifact` action behaviour (no files matching the specified pattern are found) causing the entire tests job to fail even though tests are passing